### PR TITLE
feat: include PRs labelled `auto-merge-after-CI` in the stale ready-to-merge list

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -20,7 +20,7 @@ class PRList(Enum):
 
 # All input files this script expects. Needs to be kept in sync with dashboard.sh,
 # but this script will complain if something unexpected happens.
-filenames = {
+EXPECTED_INPUT_FILES = {
     "queue.json" : PRList.Queue,
     "ready-to-merge.json" : PRList.StaleReadyToMerge,
     "maintainer-merge.json" : PRList.StaleMaintainerMerge,
@@ -39,9 +39,13 @@ def main():
 
     # Iterate over the json files provided by the user
     for i in range(2, len(sys.argv)):
-        with open(sys.argv[i]) as f:
+        filename = sys.argv[i]
+        if filename not in EXPECTED_INPUT_FILES:
+            print(f"bad argument: file {filename} is not recognised; did you mean one of these: {EXPECTED_INPUT_FILES.keys()}?")
+            sys.exit(1)
+        with open(filename) as f:
             data = json.load(f)
-            print_dashboard(data, filenames[sys.argv[i]])
+            print_dashboard(data, EXPECTED_INPUT_FILES[filename])
 
     print_html5_footer()
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -23,6 +23,7 @@ class PRList(Enum):
 EXPECTED_INPUT_FILES = {
     "queue.json" : PRList.Queue,
     "ready-to-merge.json" : PRList.StaleReadyToMerge,
+    "automerge.json" : PRList.StaleReadyToMerge,
     "maintainer-merge.json" : PRList.StaleMaintainerMerge,
     "delegated.json" : PRList.StaleDelegated,
     "new-contributor.json" : PRList.StaleNewContributor,
@@ -49,8 +50,8 @@ def main():
             dataFilesWithKind.append(data, EXPECTED_INPUT_FILES[filename])
 
     # Process all data files for the same PR list together.
-    for kind in PRList.__members__:
-        files = [k for (d, k) in dataFilesWithKind if k == kind]
+    for kind in PRList._member_map_.values():
+        files = [d for (d, k) in dataFilesWithKind if k == kind]
         print_dashboard(files, kind)
 
     print_html5_footer()

--- a/dashboard.py
+++ b/dashboard.py
@@ -6,6 +6,28 @@ import sys
 import json
 from datetime import datetime, UTC
 from dateutil import relativedelta
+from enum import Enum, unique
+
+@unique
+class PRList(Enum):
+    '''The different kind of PR lists this dashboard creates'''
+    Queue = 0
+    StaleReadyToMerge = 1
+    StaleMaintainerMerge = 2
+    StaleDelegated = 3
+    StaleNewContributor = 4
+    Unlabelled = 5
+
+# All input files this script expects. Needs to be kept in sync with dashboard.sh,
+# but this script will complain if something unexpected happens.
+filenames = {
+    "queue.json" : PRList.Queue,
+    "ready-to-merge.json" : PRList.StaleReadyToMerge,
+    "maintainer-merge.json" : PRList.StaleMaintainerMerge,
+    "delegated.json" : PRList.StaleDelegated,
+    "new-contributor.json" : PRList.StaleNewContributor,
+    "unlabelled.json" : PRList.Unlabelled,
+}
 
 def main():
     # Check if the user has provided the correct number of arguments
@@ -19,7 +41,7 @@ def main():
     for i in range(2, len(sys.argv)):
         with open(sys.argv[i]) as f:
             data = json.load(f)
-            print_dashboard(data)
+            print_dashboard(data, filenames[sys.argv[i]])
 
     print_html5_footer()
 
@@ -120,37 +142,45 @@ def time_info(updatedAt):
 
     return s
 
-def print_dashboard(data):
+def print_dashboard(data, kind : PRList):
     # If there are no PRs, skip the table header and print a bold notice such as
     # "There are currently **no** stale `delegated` PRs. Congratulations!".
     if not data["output"][0]["data"]["search"]["nodes"]:
         description = {
-            "queue" : "PRs on the review queue",
-            "stale-maintainer-merge" : "stale PRs labelled maintainer merge",
-            "stale-delegated" : "stale delegated PRs",
-            "stale-ready-to-merge" : "stale PRs labelled ready-to-merge",
-            "stale-new-contributor" : "stale PRs by new contributors",
-            "unlabelled" : "unlabelled PRs"
+            PRList.Queue : "PRs on the review queue",
+            PRList.StaleMaintainerMerge : "stale PRs labelled maintainer merge",
+            PRList.StaleDelegated : "stale delegated PRs",
+            PRList.StaleReadyToMerge : "stale PRs labelled ready-to-merge",
+            PRList.StaleNewContributor : "stale PRs by new contributors",
+            PRList.Unlabelled : "unlabelled PRs",
         }
         print("<h1 id=\"{}\">{}</h1>".format(data["id"], data["title"]))
-        print(f'There are currently <b>no</b> {description[data["id"]]}. Congratulations!\n')
+        print(f'There are currently <b>no</b> {description[kind]}. Congratulations!\n')
         return
 
     # Explain what each PR list contains.
     notupdated = "which have not been updated in the past"
     explanation = {
-        "queue" : "All PRs which are ready for review: CI passes, no merge conflict and not blocked on other PRs",
-        "unlabelled" : "PRs without a 't-something' label which are not labelled 'CI'",
-        "stale-delegated" : f"PRs labelled 'delegated' {notupdated} 24 hours",
-        "stale-ready-to-merge" : f"PRs labelled 'ready-to-merge' {notupdated} 24 hours",
-        "stale-maintainer-merge" : f"PRs labelled 'maintainer-merge' but not 'ready-to-merge' {notupdated} 24 hours",
-        "stale-new-contributor" : f"PR labelled 'new-contributor' {notupdated} 7 days",
-    }[[data["id"]]]
+        PRList.Queue : "All PRs which are ready for review: CI passes, no merge conflict and not blocked on other PRs",
+        PRList.Unlabelled : "PRs without a 't-something' label which are not labelled 'CI'",
+        PRList.StaleDelegated : f"PRs labelled 'delegated' {notupdated} 24 hours",
+        PRList.StaleReadyToMerge : f"PRs labelled 'ready-to-merge' {notupdated} 24 hours",
+        PRList.StaleMaintainerMerge : f"PRs labelled 'maintainer-merge' but not 'ready-to-merge' {notupdated} 24 hours",
+        PRList.StaleNewContributor : f"PR labelled 'new-contributor' {notupdated} 7 days",
+    }[kind]
     # Use a header to make space before the table, but don't make it bold.
     explanation = f'<h5 style="font-weight:normal">{explanation}</h5>\n'
-
-    print("<h1 id=\"{}\">{}</h1>".format(data["id"], data["title"]))
-    print(f"""{explanation}
+    # Title of each list, and the corresponding HTML anchor.
+    (id, title) = {
+        PRList.Queue : ("queue", "Queue"),
+        PRList.Unlabelled : ("unlabelled", "PRs without an area label"),
+        PRList.StaleDelegated : ("stale-delegated", "Stale delegated"),
+        PRList.StaleNewContributor : ("stale-new-contributor", "Stale new contributor"),
+        PRList.StaleMaintainerMerge : ("stale-maintainer-merge", "Stale maintainer-merge"),
+        PRList.StaleReadyToMerge : ("stale-ready-to-merge", "Stale ready-to-merge")
+    }
+    print(f"""<h1 id=\"{id}\">{title}</h1>
+    {explanation}
     <table>
     <thead>
     <tr>

--- a/dashboard.py
+++ b/dashboard.py
@@ -150,20 +150,20 @@ def print_dashboard(data):
     explanation = f'<h5 style="font-weight:normal">{explanation}</h5>\n'
 
     print("<h1 id=\"{}\">{}</h1>".format(data["id"], data["title"]))
-    print(explanation)
-    print("<table>")
-    print("<thead>")
-    print("<tr>")
-    print("<th>Number</th>")
-    print("<th>Author</th>")
-    print("<th>Title</th>")
-    print("<th>Labels</th>")
-    print("<th>+/-</th>")
-    print("<th>&#128221;</th>")
-    print("<th>&#128172;</th>")
-    print("<th>Updated</th>")
-    print("</tr>")
-    print("</thead>")
+    print(f"""{explanation}
+    <table>
+    <thead>
+    <tr>
+    <th>Number</th>
+    <th>Author</th>
+    <th>Title</th>
+    <th>Labels</th>
+    <th>+/-</th>
+    <th>&#128221;</th>
+    <th>&#128172;</th>
+    <th>Updated</th>
+    </tr>
+    </thead>""")
 
     # Open the file containing the PR info
     with open(sys.argv[1], 'r') as f:

--- a/dashboard.py
+++ b/dashboard.py
@@ -130,6 +130,7 @@ def print_dashboard(data):
             "stale-delegated" : "stale delegated PRs",
             "stale-ready-to-merge" : "stale PRs labelled ready-to-merge",
             "stale-new-contributor" : "stale PRs by new contributors",
+            "unlabelled" : "unlabelled PRs"
         }
         print("<h1 id=\"{}\">{}</h1>".format(data["id"], data["title"]))
         print(f'There are currently <b>no</b> {description[data["id"]]}. Congratulations!\n')

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -65,8 +65,13 @@ QUERY_NEWCONTRIBUTOR=$(prepare_query "sort:updated-asc is:pr state:open label:ne
 gh api graphql --paginate --slurp -f query="$QUERY_NEWCONTRIBUTOR" |\
 	jq '{"output": ., "title": "Stale new-contributor", "id": "stale-new-contributor"}' > new-contributor.json
 
+# Query Github API for all open pull requests without the label "CI" or a "topic" label.
+QUERY_UNLABELLED=$(prepare_query 'sort:updated-asc is:open is:pr in:title "feat" -label:t-algebra -label:t-linter -label:t-logic -label:t-number-theory -label:t-topology -label:t-order -label:t-category-theory -label:t-analysis -label:t-dynamics -label:t-combinatorics -label:t-measure-probability -label:t-algebraic-geometry -label:t-meta -label:t-computability -label:t-differential-geometry -label:t-euclidean-geometry -label:t-data -label:CI')
+gh api graphql --paginate --slurp -f query="$QUERY_UNLABELLED" |\
+	jq '{"output": ., "title": "PRs without an area label", "id": "unlabelled"}' > unlabelled.json
+
 # List of JSON files
-json_files=("queue.json" "ready-to-merge.json" "maintainer-merge.json" "delegated.json" "new-contributor.json")
+json_files=("queue.json" "ready-to-merge.json" "maintainer-merge.json" "delegated.json" "new-contributor.json" "unlabelled.json")
 
 # Output file
 pr_info="pr-info.json"

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -49,6 +49,14 @@ gh api graphql --paginate --slurp -f query="$QUERY_QUEUE" |\
 QUERY_READYTOMERGE=$(prepare_query "sort:updated-asc is:pr state:open label:ready-to-merge updated:<$yesterday")
 gh api graphql --paginate --slurp -f query="$QUERY_READYTOMERGE" |\
 	jq '{"output": ., "title": "Stale ready-to-merge", "id": "stale-ready-to-merge"}' > ready-to-merge.json
+# Add to this the list of stale PRs with `auto-merge-after-CI`.
+
+QUERY_AUTOMERGE=$(prepare_query "sort:updated-asc is:pr state:open label:auto-merge-after-CI updated:<$yesterday")
+gh api graphql --paginate --slurp -f query="$QUERY_AUTOMERGE" |\
+	jq '{"output": ., "title": "Stale ready-to-merge", "id": "stale-ready-to-merge"}' > automerge.json
+# TODO: merge automerge.json into this; not sure how...
+# see https://stackoverflow.com/questions/42245288/add-new-element-to-existing-json-array-with-jq on how to...
+# and I cannot test any of this, which is annoying!
 
 # Query Github API for all pull requests that are labeled `maintainer-merge` but not `ready-to-merge` and have not been updated in 24 hours.
 QUERY_MAINTAINERMERGE=$(prepare_query "sort:updated-asc is:pr state:open label:maintainer-merge -label:ready-to-merge updated:<$yesterday")


### PR DESCRIPTION
Depends on #22 and #23 (preliminary refactoring).
TODO: after these have landed, rebase and make the history pretty... some of these commits should be merged

Github's API does not allow querying with logical OR (as far as I can tell) - hence we perform two separate queries and merge the data when creating the PR lists.
I decided to simply do this in Python (instead of getting `jq` to merge the data files).
In the process of making this, I refactored the script to validate the json file names passed in, and map these to the PR lists it expects. (This coupling with the shell script is unfortunate, but I made sure it will fail loudly otherwise. On the other hand, this allows up remove the `title` and `id` fields from the shell output to Python, which is also nice.)

Fixes #8.