### PR TITLE
feat: miscellaneous changes

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -39,6 +39,7 @@ def print_html5_header():
     </head>
     <body>
     <h1>Mathlib Review Dashboard</h1>""")
+    # FUTURE: can this time be displayed in the local time zone of the user viewing this page?
     updated = datetime.now(UTC).strftime("%B %d, %Y at %H:%M UTC")
     print(f"<small>This dashboard was last updated on: {updated}</small>")
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -4,7 +4,7 @@
 
 import sys
 import json
-from datetime import datetime
+from datetime import datetime, UTC
 from dateutil import relativedelta
 
 def main():
@@ -38,8 +38,9 @@ def print_html5_header():
     <base target="_blank">
     </head>
     <body>
-    <h1>Mathlib Review Dashboard</h1>
-    """)
+    <h1>Mathlib Review Dashboard</h1>""")
+    updated = datetime.now(UTC).strftime("%B %d, %Y at %H:%M UTC")
+    print(f"<small>This dashboard was last updated on: {updated}</small>")
 
 def print_html5_footer():
     print("""

--- a/dashboard.py
+++ b/dashboard.py
@@ -76,7 +76,7 @@ def label_link(label):
     # adapted from https://codepen.io/WebSeed/pen/pvgqEq
     def isLight(r, g, b):
         # Counting the perceptive luminance
-        # human eye favors green color... 
+        # human eye favors green color...
         a = 1 - (0.299 * r + 0.587 * g + 0.114 * b) / 255
         return (a < 0.5)
 
@@ -119,7 +119,7 @@ def time_info(updatedAt):
     return s
 
 def print_dashboard(data):
-    print("<h1>{}</h1>".format(data["title"]))
+    print("<h1 id=\"{}\">{}</h1>".format(data["id"], data["title"]))
     print("<table>")
     print("<thead>")
     print("<tr>")

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -40,28 +40,28 @@ query(\$endCursor: String) {
 # - do not have any of the following labels: blocked-by-other-PR, merge-conflict, awaiting-CI, WIP, awaiting-author, delegated, auto-merge-after-CI
 QUERY_QUEUE=$(prepare_query "sort:updated-asc is:pr state:open -is:draft -status:failure -label:blocked-by-other-PR -label:merge-conflict -label:awaiting-CI -label:awaiting-author -label:WIP -label:delegated -label:auto-merge-after-CI")
 gh api graphql --paginate --slurp -f query="$QUERY_QUEUE" |\
-	jq '{"output": ., "title": "Queue"}' > queue.json
+	jq '{"output": ., "title": "Queue", "id": "queue"}' > queue.json
 
 
 # Query Github API for all pull requests that are labeled `ready-to-merge` and have not been updated in 24 hours.
 QUERY_READYTOMERGE=$(prepare_query "sort:updated-asc is:pr state:open label:ready-to-merge updated:<$yesterday")
 gh api graphql --paginate --slurp -f query="$QUERY_READYTOMERGE" |\
-	jq '{"output": ., "title": "Stale ready-to-merge"}' > ready-to-merge.json
+	jq '{"output": ., "title": "Stale ready-to-merge", "id": "stale-ready-to-merge"}' > ready-to-merge.json
 
 # Query Github API for all pull requests that are labeled `maintainer-merge` but not `ready-to-merge` and have not been updated in 24 hours.
 QUERY_MAINTAINERMERGE=$(prepare_query "sort:updated-asc is:pr state:open label:maintainer-merge -label:ready-to-merge updated:<$yesterday")
 gh api graphql --paginate --slurp -f query="$QUERY_MAINTAINERMERGE" |\
-	jq '{"output": ., "title": "Stale maintainer-merge"}' > maintainer-merge.json
+	jq '{"output": ., "title": "Stale maintainer-merge", "id": "stale-maintainer-merge"}' > maintainer-merge.json
 
 # Query Github API for all pull requests that are labeled `delegated` and have not been updated in 24 hours.
 QUERY_READYTOMERGE=$(prepare_query "sort:updated-asc is:pr state:open label:delegated updated:<$yesterday")
 gh api graphql --paginate --slurp -f query="$QUERY_READYTOMERGE" |\
-	jq '{"output": ., "title": "Stale delegated"}' > delegated.json
+	jq '{"output": ., "title": "Stale delegated", "id": "stale-delegated"}' > delegated.json
 
 # Query Github API for all pull requests that are labeled `new-contributor` and have not been updated in 24 hours.
 QUERY_NEWCONTRIBUTOR=$(prepare_query "sort:updated-asc is:pr state:open label:new-contributor updated:<$yesterday")
 gh api graphql --paginate --slurp -f query="$QUERY_NEWCONTRIBUTOR" |\
-	jq '{"output": ., "title": "Stale new-contributor"}' > new-contributor.json
+	jq '{"output": ., "title": "Stale new-contributor", "id": "stale-new-contributor"}' > new-contributor.json
 
 # List of JSON files
 json_files=("queue.json" "ready-to-merge.json" "maintainer-merge.json" "delegated.json" "new-contributor.json")

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -54,8 +54,8 @@ gh api graphql --paginate --slurp -f query="$QUERY_MAINTAINERMERGE" |\
 	jq '{"output": ., "title": "Stale maintainer-merge", "id": "stale-maintainer-merge"}' > maintainer-merge.json
 
 # Query Github API for all pull requests that are labeled `delegated` and have not been updated in 24 hours.
-QUERY_READYTOMERGE=$(prepare_query "sort:updated-asc is:pr state:open label:delegated updated:<$yesterday")
-gh api graphql --paginate --slurp -f query="$QUERY_READYTOMERGE" |\
+QUERY_DELEGATED=$(prepare_query "sort:updated-asc is:pr state:open label:delegated updated:<$yesterday")
+gh api graphql --paginate --slurp -f query="$QUERY_DELEGATED" |\
 	jq '{"output": ., "title": "Stale delegated", "id": "stale-delegated"}' > delegated.json
 
 # Query Github API for all pull requests that are labeled `new-contributor` and have not been updated in 24 hours.


### PR DESCRIPTION
- add an anchor to each table: this allows jumping directly to each section
This is useful if linkifiers want to link to certain sections. A future PR could also add navigation facilities at the top of the page. Both ideas are left as future work.
- Rename a misleading variable (likely the result of copy-paste).
- Note when the dashboard was last updated: that's one of my first questions when looking at it :-)

Mostly addresses #4 (it does not look at the PR titles).