### PR TITLE
fix: downgrade import

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -4,7 +4,7 @@
 
 import sys
 import json
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from dateutil import relativedelta
 
 def main():
@@ -40,7 +40,7 @@ def print_html5_header():
     <body>
     <h1>Mathlib Review Dashboard</h1>""")
     # FUTURE: can this time be displayed in the local time zone of the user viewing this page?
-    updated = datetime.now(UTC).strftime("%B %d, %Y at %H:%M UTC")
+    updated = datetime.now(timezone.utc).strftime("%B %d, %Y at %H:%M UTC")
     print(f"<small>This dashboard was last updated on: {updated}</small>")
 
 def print_html5_footer():


### PR DESCRIPTION
`datetime.UTC` was only added on Python 3.11, while the workflow running is using an older version.
It is an alias for `datetime.timezone.utc`, so use that instead.