### PR TITLE
refactor: track different kinds of tables in the Python script

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -29,7 +29,7 @@ EXPECTED_INPUT_FILES = {
 
 def short_description(kind : PRList):
     '''Describe what the table 'kind' contains, for use in a "there are no such PRs" message.'''
-    {
+    return {
         PRList.Queue : "PRs on the review queue",
         PRList.StaleMaintainerMerge : "stale PRs labelled maintainer merge",
         PRList.StaleDelegated : "stale delegated PRs",
@@ -41,7 +41,7 @@ def long_description(kind : PRList):
     '''Explain what each PR list contains: full description, for the purposes of a sub-title
     to the full PR table.'''
     notupdated = "which have not been updated in the past"
-    {
+    return {
         PRList.Queue : "All PRs which are ready for review: CI passes, no merge conflict and not blocked on other PRs",
         PRList.StaleDelegated : f"PRs labelled 'delegated' {notupdated} 24 hours",
         PRList.StaleReadyToMerge : f"PRs labelled 'ready-to-merge' {notupdated} 24 hours",
@@ -52,7 +52,7 @@ def long_description(kind : PRList):
 def getIdTitle(kind : PRList):
     '''Return a tuple (id, title) of the HTML anchor ID and a section name for the table
     describing this PR kind.'''
-    {
+    return {
         PRList.Queue : ("queue", "Queue"),
         PRList.StaleDelegated : ("stale-delegated", "Stale delegated"),
         PRList.StaleNewContributor : ("stale-new-contributor", "Stale new contributor"),

--- a/dashboard.py
+++ b/dashboard.py
@@ -27,7 +27,7 @@ EXPECTED_INPUT_FILES = {
     "new-contributor.json" : PRList.StaleNewContributor,
 }
 
-def description_none(kind : PRList):
+def short_description(kind : PRList):
     '''Describe what the table 'kind' contains, for use in a "there are no such PRs" message.'''
     {
         PRList.Queue : "PRs on the review queue",
@@ -37,11 +37,11 @@ def description_none(kind : PRList):
         PRList.StaleNewContributor : "stale PRs by new contributors",
     }[kind]
 
-def explanation(kind : PRList):
+def long_description(kind : PRList):
     '''Explain what each PR list contains: full description, for the purposes of a sub-title
     to the full PR table.'''
     notupdated = "which have not been updated in the past"
-    explanation = {
+    {
         PRList.Queue : "All PRs which are ready for review: CI passes, no merge conflict and not blocked on other PRs",
         PRList.Unlabelled : "PRs without a 't-something' label which are not labelled 'CI'",
         PRList.StaleDelegated : f"PRs labelled 'delegated' {notupdated} 24 hours",
@@ -184,11 +184,11 @@ def print_dashboard(data, kind : PRList):
     # "There are currently **no** stale `delegated` PRs. Congratulations!".
     if not data["output"][0]["data"]["search"]["nodes"]:
         print("<h1 id=\"{}\">{}</h1>".format(data["id"], data["title"]))
-        print(f'There are currently <b>no</b> {description_none(kind)}. Congratulations!\n')
+        print(f'There are currently <b>no</b> {short_description(kind)}. Congratulations!\n')
         return
     # Explain what each PR list contains.
     # Use a header to make space before the table, but don't make it bold.
-    explanation = f'<h5 style="font-weight:normal">{explanation(kind)}</h5>\n'
+    explanation = f'<h5 style="font-weight:normal">{long_description(kind)}</h5>\n'
     # Title of each list, and the corresponding HTML anchor.
     (id, title) = getIdTitle(kind)
     print(f"""<h1 id=\"{id}\">{title}</h1>

--- a/dashboard.py
+++ b/dashboard.py
@@ -43,7 +43,6 @@ def long_description(kind : PRList):
     notupdated = "which have not been updated in the past"
     {
         PRList.Queue : "All PRs which are ready for review: CI passes, no merge conflict and not blocked on other PRs",
-        PRList.Unlabelled : "PRs without a 't-something' label which are not labelled 'CI'",
         PRList.StaleDelegated : f"PRs labelled 'delegated' {notupdated} 24 hours",
         PRList.StaleReadyToMerge : f"PRs labelled 'ready-to-merge' {notupdated} 24 hours",
         PRList.StaleMaintainerMerge : f"PRs labelled 'maintainer-merge' but not 'ready-to-merge' {notupdated} 24 hours",
@@ -55,7 +54,6 @@ def getIdTitle(kind : PRList):
     describing this PR kind.'''
     {
         PRList.Queue : ("queue", "Queue"),
-        PRList.Unlabelled : ("unlabelled", "PRs without an area label"),
         PRList.StaleDelegated : ("stale-delegated", "Stale delegated"),
         PRList.StaleNewContributor : ("stale-new-contributor", "Stale new contributor"),
         PRList.StaleMaintainerMerge : ("stale-maintainer-merge", "Stale maintainer-merge"),

--- a/dashboard.py
+++ b/dashboard.py
@@ -19,7 +19,7 @@ class PRList(Enum):
 
 # All input files this script expects. Needs to be kept in sync with dashboard.sh,
 # but this script will complain if something unexpected happens.
-filenames = {
+EXPECTED_INPUT_FILES = {
     "queue.json" : PRList.Queue,
     "ready-to-merge.json" : PRList.StaleReadyToMerge,
     "maintainer-merge.json" : PRList.StaleMaintainerMerge,
@@ -72,9 +72,13 @@ def main():
 
     # Iterate over the json files provided by the user
     for i in range(2, len(sys.argv)):
-        with open(sys.argv[i]) as f:
+        filename = sys.argv[i]
+        if filename not in EXPECTED_INPUT_FILES:
+            print(f"bad argument: file {filename} is not recognised; did you mean one of these: {EXPECTED_INPUT_FILES.keys()}?")
+            sys.exit(1)
+        with open(filename) as f:
             data = json.load(f)
-            print_dashboard(data, filenames[sys.argv[i]])
+            print_dashboard(data, EXPECTED_INPUT_FILES[filename])
 
     print_html5_footer()
 

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -45,29 +45,24 @@ query(\$endCursor: String) {
 # - do not have status:failure
 # - do not have any of the following labels: blocked-by-other-PR, merge-conflict, awaiting-CI, WIP, awaiting-author, delegated, auto-merge-after-CI
 QUERY_QUEUE=$(prepare_query "sort:updated-asc is:pr state:open -is:draft -status:failure -label:blocked-by-other-PR -label:merge-conflict -label:awaiting-CI -label:awaiting-author -label:WIP -label:delegated -label:auto-merge-after-CI")
-gh api graphql --paginate --slurp -f query="$QUERY_QUEUE" |\
-	jq '{"output": .}' > queue.json
+gh api graphql --paginate --slurp -f query="$QUERY_QUEUE" | jq '{"output": .}' > queue.json
 
 
 # Query Github API for all pull requests that are labeled `ready-to-merge` and have not been updated in 24 hours.
 QUERY_READYTOMERGE=$(prepare_query "sort:updated-asc is:pr state:open label:ready-to-merge updated:<$yesterday")
-gh api graphql --paginate --slurp -f query="$QUERY_READYTOMERGE" |\
-	jq '{"output": ., "title": "Stale ready-to-merge", "id": "stale-ready-to-merge"}' > ready-to-merge.json
+gh api graphql --paginate --slurp -f query="$QUERY_READYTOMERGE" | jq '{"output": . }' > ready-to-merge.json
 
 # Query Github API for all pull requests that are labeled `maintainer-merge` but not `ready-to-merge` and have not been updated in 24 hours.
 QUERY_MAINTAINERMERGE=$(prepare_query "sort:updated-asc is:pr state:open label:maintainer-merge -label:ready-to-merge updated:<$yesterday")
-gh api graphql --paginate --slurp -f query="$QUERY_MAINTAINERMERGE" |\
-	jq '{"output": .}' > maintainer-merge.json
+gh api graphql --paginate --slurp -f query="$QUERY_MAINTAINERMERGE" | jq '{"output": .}' > maintainer-merge.json
 
 # Query Github API for all pull requests that are labeled `delegated` and have not been updated in 24 hours.
 QUERY_DELEGATED=$(prepare_query "sort:updated-asc is:pr state:open label:delegated updated:<$yesterday")
-gh api graphql --paginate --slurp -f query="$QUERY_DELEGATED" |\
-	jq '{"output": .}' > delegated.json
+gh api graphql --paginate --slurp -f query="$QUERY_DELEGATED" | jq '{"output": .}' > delegated.json
 
 # Query Github API for all pull requests that are labeled `new-contributor` and have not been updated in seven days.
 QUERY_NEWCONTRIBUTOR=$(prepare_query "sort:updated-asc is:pr state:open label:new-contributor updated:<$aweekago")
-gh api graphql --paginate --slurp -f query="$QUERY_NEWCONTRIBUTOR" |\
-	jq '{"output": .}' > new-contributor.json
+gh api graphql --paginate --slurp -f query="$QUERY_NEWCONTRIBUTOR" | jq '{"output": .}' > new-contributor.json
 
 # List of JSON files
 json_files=("queue.json" "ready-to-merge.json" "maintainer-merge.json" "delegated.json" "new-contributor.json")

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -46,7 +46,7 @@ query(\$endCursor: String) {
 # - do not have any of the following labels: blocked-by-other-PR, merge-conflict, awaiting-CI, WIP, awaiting-author, delegated, auto-merge-after-CI
 QUERY_QUEUE=$(prepare_query "sort:updated-asc is:pr state:open -is:draft -status:failure -label:blocked-by-other-PR -label:merge-conflict -label:awaiting-CI -label:awaiting-author -label:WIP -label:delegated -label:auto-merge-after-CI")
 gh api graphql --paginate --slurp -f query="$QUERY_QUEUE" |\
-	jq '{"output": ., "title": "Queue", "id": "queue"}' > queue.json
+	jq '{"output": .}' > queue.json
 
 
 # Query Github API for all pull requests that are labeled `ready-to-merge` and have not been updated in 24 hours.
@@ -57,17 +57,17 @@ gh api graphql --paginate --slurp -f query="$QUERY_READYTOMERGE" |\
 # Query Github API for all pull requests that are labeled `maintainer-merge` but not `ready-to-merge` and have not been updated in 24 hours.
 QUERY_MAINTAINERMERGE=$(prepare_query "sort:updated-asc is:pr state:open label:maintainer-merge -label:ready-to-merge updated:<$yesterday")
 gh api graphql --paginate --slurp -f query="$QUERY_MAINTAINERMERGE" |\
-	jq '{"output": ., "title": "Stale maintainer-merge", "id": "stale-maintainer-merge"}' > maintainer-merge.json
+	jq '{"output": .}' > maintainer-merge.json
 
 # Query Github API for all pull requests that are labeled `delegated` and have not been updated in 24 hours.
 QUERY_DELEGATED=$(prepare_query "sort:updated-asc is:pr state:open label:delegated updated:<$yesterday")
 gh api graphql --paginate --slurp -f query="$QUERY_DELEGATED" |\
-	jq '{"output": ., "title": "Stale delegated", "id": "stale-delegated"}' > delegated.json
+	jq '{"output": .}' > delegated.json
 
 # Query Github API for all pull requests that are labeled `new-contributor` and have not been updated in seven days.
 QUERY_NEWCONTRIBUTOR=$(prepare_query "sort:updated-asc is:pr state:open label:new-contributor updated:<$aweekago")
 gh api graphql --paginate --slurp -f query="$QUERY_NEWCONTRIBUTOR" |\
-	jq '{"output": ., "title": "Stale new-contributor", "id": "stale-new-contributor"}' > new-contributor.json
+	jq '{"output": .}' > new-contributor.json
 
 # List of JSON files
 json_files=("queue.json" "ready-to-merge.json" "maintainer-merge.json" "delegated.json" "new-contributor.json")


### PR DESCRIPTION
- Define an enumeration of all kinds of tables this script generates.
- Determine the PR title and description from this kind; this means we may remove the corresponding entries in the bash script.
- To prevent the .sh and .py script from getting out of sync, complain if any unexpected file was passed to the Python script.

This sets the ground-work for #16: mapping files to PR tables will allow merging json files on the Python side.