### PR TITLE
feat: include PRs labelled auto-merge-after-CI in the stale ready-to-merge list

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -34,7 +34,7 @@ def short_description(kind : PRList):
         PRList.Queue : "PRs on the review queue",
         PRList.StaleMaintainerMerge : "stale PRs labelled maintainer merge",
         PRList.StaleDelegated : "stale delegated PRs",
-        PRList.StaleReadyToMerge : "stale PRs labelled ready-to-merge",
+        PRList.StaleReadyToMerge : "stale PRs labelled auto-merge-after-CI or ready-to-merge",
         PRList.StaleNewContributor : "stale PRs by new contributors",
     }[kind]
 
@@ -45,7 +45,7 @@ def long_description(kind : PRList):
     return {
         PRList.Queue : "All PRs which are ready for review: CI passes, no merge conflict and not blocked on other PRs",
         PRList.StaleDelegated : f"PRs labelled 'delegated' {notupdated} 24 hours",
-        PRList.StaleReadyToMerge : f"PRs labelled 'ready-to-merge' {notupdated} 24 hours",
+        PRList.StaleReadyToMerge : f"PRs labelled 'auto-merge-after-CI' or 'ready-to-merge' {notupdated} 24 hours",
         PRList.StaleMaintainerMerge : f"PRs labelled 'maintainer-merge' but not 'ready-to-merge' {notupdated} 24 hours",
         PRList.StaleNewContributor : f"PR labelled 'new-contributor' {notupdated} 7 days",
     }[kind]

--- a/dashboard.py
+++ b/dashboard.py
@@ -186,16 +186,17 @@ def time_info(updatedAt):
 
 from typing import List
 
-def print_dashboard(datae : List[any], kind : PRList):
+def print_dashboard(datae : List[dict], kind : PRList):
     '''`datae` is a list of parsed data files to process'''
     # Title of each list, and the corresponding HTML anchor.
     (id, title) = getIdTitle(kind)
     print("<h1 id=\"{}\">{}</h1>".format(id, title))
     # If there are no PRs, skip the table header and print a bold notice such as
     # "There are currently **no** stale `delegated` PRs. Congratulations!".
-    if all(data for data in datae if not data["output"][0]["data"]["search"]["nodes"]):
+    if not any([data for data in datae if data["output"][0]["data"]["search"]["nodes"]]):
         print(f'There are currently <b>no</b> {short_description(kind)}. Congratulations!\n')
         return
+
     # Explain what each PR list contains.
     # Use a header to make space before the table, but don't make it bold.
     print(f"""<h5 style="font-weight:normal">{long_description(kind)}</h5>

--- a/dashboard.py
+++ b/dashboard.py
@@ -78,7 +78,7 @@ def main():
             sys.exit(1)
         with open(filename) as f:
             data = json.load(f)
-            dataFilesWithKind.append(data, EXPECTED_INPUT_FILES[filename])
+            dataFilesWithKind.append((data, EXPECTED_INPUT_FILES[filename]))
     # Process all data files for the same PR list together.
     for kind in PRList._member_map_.values():
         files = [d for (d, k) in dataFilesWithKind if k == kind]
@@ -192,8 +192,7 @@ def print_dashboard(datae : List[any], kind : PRList):
     print("<h1 id=\"{}\">{}</h1>".format(id, title))
     # If there are no PRs, skip the table header and print a bold notice such as
     # "There are currently **no** stale `delegated` PRs. Congratulations!".
-    if all(datae, lambda data : not data["output"][0]["data"]["search"]["nodes"]):
-
+    if all(data for data in datae if not data["output"][0]["data"]["search"]["nodes"]):
         print(f'There are currently <b>no</b> {short_description(kind)}. Congratulations!\n')
         return
     # Explain what each PR list contains.

--- a/dashboard.py
+++ b/dashboard.py
@@ -178,19 +178,18 @@ def time_info(updatedAt):
     return s
 
 def print_dashboard(data, kind : PRList):
+    # Title of each list, and the corresponding HTML anchor.
+    (id, title) = getIdTitle(kind)
+    print("<h1 id=\"{}\">{}</h1>".format(id, title))
+
     # If there are no PRs, skip the table header and print a bold notice such as
     # "There are currently **no** stale `delegated` PRs. Congratulations!".
     if not data["output"][0]["data"]["search"]["nodes"]:
-        print("<h1 id=\"{}\">{}</h1>".format(data["id"], data["title"]))
         print(f'There are currently <b>no</b> {short_description(kind)}. Congratulations!\n')
         return
     # Explain what each PR list contains.
     # Use a header to make space before the table, but don't make it bold.
-    explanation = f'<h5 style="font-weight:normal">{long_description(kind)}</h5>\n'
-    # Title of each list, and the corresponding HTML anchor.
-    (id, title) = getIdTitle(kind)
-    print(f"""<h1 id=\"{id}\">{title}</h1>
-    {explanation}
+    print(f"""<h5 style="font-weight:normal">{long_description(kind)}</h5>
     <table>
     <thead>
     <tr>

--- a/dashboard.py
+++ b/dashboard.py
@@ -21,6 +21,7 @@ class PRList(Enum):
 # but this script will complain if something unexpected happens.
 EXPECTED_INPUT_FILES = {
     "queue.json" : PRList.Queue,
+    "automerge.json" : PRList.StaleReadyToMerge,
     "ready-to-merge.json" : PRList.StaleReadyToMerge,
     "maintainer-merge.json" : PRList.StaleMaintainerMerge,
     "delegated.json" : PRList.StaleDelegated,

--- a/dashboard.py
+++ b/dashboard.py
@@ -79,10 +79,11 @@ def main():
         with open(filename) as f:
             data = json.load(f)
             dataFilesWithKind.append((data, EXPECTED_INPUT_FILES[filename]))
+
     # Process all data files for the same PR list together.
     for kind in PRList._member_map_.values():
-        files = [d for (d, k) in dataFilesWithKind if k == kind]
-        print_dashboard(files, kind)
+        datae = [d for (d, k) in dataFilesWithKind if k == kind]
+        print_dashboard(datae, kind)
 
     print_html5_footer()
 

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -52,6 +52,11 @@ gh api graphql --paginate --slurp -f query="$QUERY_QUEUE" | jq '{"output": .}' >
 QUERY_READYTOMERGE=$(prepare_query "sort:updated-asc is:pr state:open label:ready-to-merge updated:<$yesterday")
 gh api graphql --paginate --slurp -f query="$QUERY_READYTOMERGE" | jq '{"output": . }' > ready-to-merge.json
 
+# Query Github API for all pull requests that are labeled `auto-merge-after-CI` and have not been updated in 24 hours.
+QUERY_AUTOMERGE=$(prepare_query "sort:updated-asc is:pr state:open label:auto-merge-after-CI updated:<$yesterday")
+gh api graphql --paginate --slurp -f query="$QUERY_AUTOMERGE" | jq '{"output": . }' > automerge.json
+
+
 # Query Github API for all pull requests that are labeled `maintainer-merge` but not `ready-to-merge` and have not been updated in 24 hours.
 QUERY_MAINTAINERMERGE=$(prepare_query "sort:updated-asc is:pr state:open label:maintainer-merge -label:ready-to-merge updated:<$yesterday")
 gh api graphql --paginate --slurp -f query="$QUERY_MAINTAINERMERGE" | jq '{"output": .}' > maintainer-merge.json
@@ -65,7 +70,7 @@ QUERY_NEWCONTRIBUTOR=$(prepare_query "sort:updated-asc is:pr state:open label:ne
 gh api graphql --paginate --slurp -f query="$QUERY_NEWCONTRIBUTOR" | jq '{"output": .}' > new-contributor.json
 
 # List of JSON files
-json_files=("queue.json" "ready-to-merge.json" "maintainer-merge.json" "delegated.json" "new-contributor.json")
+json_files=("queue.json" "ready-to-merge.json" "automerge.json" "maintainer-merge.json" "delegated.json" "new-contributor.json")
 
 # Output file
 pr_info="pr-info.json"


### PR DESCRIPTION
Github's API does not allow querying with logical OR (as far as I can tell) - hence we perform two separate queries and merge the data when creating the PR table. I decided to simply do this in Python (instead of getting jq to merge the data files).
This is where the refactoring from #23 is useful.

As a by-product, fix a bug in the display of empty tables, introduced in #23.
Commits can be reviewed individually; the last commit is best reviewed with whitespace changes ignored.

Re-done version of #16 (this was easier than rebasing). Fixes #8.