### PR TITLE
refactor: make dashboard printing code more typed

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -152,7 +152,7 @@ def title_link(title, url):
 # The information we need about each PR label: name, colour and URL
 class Label(NamedTuple):
     name : str
-    '''This label's background colour, as a six-digit hexadeciaml code'''
+    '''This label's background colour, as a six-digit hexadecimal code'''
     color : str
     url : str
 


### PR DESCRIPTION
Extract the core logic for 'print these PR entries' into a separate function, and use this opportunity to make the printing code more typed. This will allow manually filtering a list of PRs on the Python side.

I verified locally that this generated virtually identical HTML output: the only difference are 'last updated on' date and the 'X days ago', as expected.