### PR TITLE
feat: improve query for unlabelled PRs; add list of PRs with a bad title

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -256,14 +256,14 @@ def _print_pr_entries(pr_infos, prs : List[BasicPRInformation]):
         print("</tr>")
 
 
-def print_dashboard(datae : List[dict], kind : PRList):
-    '''`datae` is a list of parsed data files to process'''
+# Print a dashboard of a given list of PRs.
+def _print_dashboard(pr_infos, prs : List[BasicPRInformation], kind: PRList):
     # Title of each list, and the corresponding HTML anchor.
     (id, title) = getIdTitle(kind)
     print("<h1 id=\"{}\">{}</h1>".format(id, title))
     # If there are no PRs, skip the table header and print a bold notice such as
     # "There are currently **no** stale `delegated` PRs. Congratulations!".
-    if not any([data for data in datae if data["output"][0]["data"]["search"]["nodes"]]):
+    if not prs:
         print(f'There are currently <b>no</b> {short_description(kind)}. Congratulations!\n')
         return
 
@@ -284,22 +284,28 @@ def print_dashboard(datae : List[dict], kind : PRList):
     </tr>
     </thead>""")
 
-    # Open the file containing the PR info.
-    with open(sys.argv[1], 'r') as f:
-        pr_infos = json.load(f)
-
-        # Print all PRs in all the data files.
-        prs_to_show = []
-        for data in datae:
-            for page in data["output"]:
-                for entry in page["data"]["search"]["nodes"]:
-                    labels = [Label(label["name"], label["color"], label["url"]) for label in entry["labels"]["nodes"]]
-                    prs_to_show.append(BasicPRInformation(
-                        entry["number"], entry["author"], entry["title"], entry["url"], labels, entry["updatedAt"]
-                    ))
-        _print_pr_entries(pr_infos, prs_to_show)
+    _print_pr_entries(pr_infos, prs)
 
     # Print the footer
     print("</table>")
+
+
+def print_dashboard(datae : List[dict], kind : PRList):
+    '''`datae` is a list of parsed data files to process'''
+
+    # Print all PRs in all the data files.
+    prs_to_show = []
+    for data in datae:
+        for page in data["output"]:
+            for entry in page["data"]["search"]["nodes"]:
+                labels = [Label(label["name"], label["color"], label["url"]) for label in entry["labels"]["nodes"]]
+                prs_to_show.append(BasicPRInformation(
+                    entry["number"], entry["author"], entry["title"], entry["url"], labels, entry["updatedAt"]
+                ))
+    # Open the file containing the PR info.
+    with open(sys.argv[1], 'r') as f:
+        pr_infos = json.load(f)
+        _print_dashboard(pr_infos, prs_to_show, kind)
+
 
 main()

--- a/dashboard.py
+++ b/dashboard.py
@@ -215,6 +215,7 @@ class BasicPRInformation(NamedTuple):
     # Github's answer to "last updated at"
     updatedAt : str
 
+
 # Print table entries about a sequence of PRs.
 def _print_pr_entries(pr_infos, prs : List[BasicPRInformation]):
     for pr in prs:

--- a/dashboard.py
+++ b/dashboard.py
@@ -81,14 +81,14 @@ def getIdTitle(kind : PRList):
 def main():
     # Check if the user has provided the correct number of arguments
     if len(sys.argv) < 3:
-        print("Usage: python3 dashboard.py <pr-info.json> <json_file1> <json_file2> ...")
+        print("Usage: python3 dashboard.py <pr-info.json> <all-ready-prs.json> <json_file1> <json_file2> ...")
         sys.exit(1)
 
     print_html5_header()
 
     # Iterate over the json files provided by the user
     dataFilesWithKind = []
-    for i in range(2, len(sys.argv)):
+    for i in range(3, len(sys.argv)):
         filename = sys.argv[i]
         if filename not in EXPECTED_INPUT_FILES:
             print(f"bad argument: file {filename} is not recognised; did you mean one of these?\n{', '.join(EXPECTED_INPUT_FILES.keys())}")
@@ -104,6 +104,10 @@ def main():
         datae = [d for (d, k) in dataFilesWithKind if k == kind]
         print_dashboard(datae, kind)
 
+    with open(sys.argv[2]) as f:
+        all_ready_prs = json.load(f)
+        print_dashboard([all_ready_prs], PRList.BadTitle) # TODO: this prints *all* PRs!!!
+        print_dashboard([all_ready_prs], PRList.Unlabelled) # TODO: this prints *all* PRs!!!
 
     print_html5_footer()
 

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -74,12 +74,13 @@ gh api graphql --paginate --slurp -f query="$QUERY_DELEGATED" | jq '{"output": .
 QUERY_NEWCONTRIBUTOR=$(prepare_query "sort:updated-asc is:pr state:open label:new-contributor updated:<$aweekago")
 gh api graphql --paginate --slurp -f query="$QUERY_NEWCONTRIBUTOR" | jq '{"output": .}' > new-contributor.json
 
-# Query Github API for all open pull requests without the label "CI" or a "topic" label.
-QUERY_UNLABELLED=$(prepare_query 'sort:updated-asc is:pr state:open -label:t-algebra -label:t-linter -label:t-logic -label:t-number-theory -label:t-topology -label:t-order -label:t-category-theory -label:t-analysis -label:t-dynamics -label:t-combinatorics -label:t-measure-probability -label:t-algebraic-geometry -label:t-meta -label:t-computability -label:t-differential-geometry -label:t-euclidean-geometry -label:t-data -label:CI' "feat")
-gh api graphql --paginate --slurp -f query="$QUERY_UNLABELLED" | jq '{"output": .}' > unlabelled.json
+# Query Github API for all open pull requests which are ready (without a WIP label or draft status).
+QUERY_READY=$(prepare_query 'sort:updated-asc is:pr -is:draft state:open -label:WIP')
+gh api graphql --paginate --slurp -f query="$QUERY_UNLABELLED" | jq '{"output": .}' > all-ready-PRs.json
 
 # List of JSON files
-json_files=("queue.json" "queue-new-contributor.json" "unlabelled.json" "ready-to-merge.json" "automerge.json" "maintainer-merge.json" "delegated.json" "new-contributor.json")
+# NB: we purposefully do not add 'all-ready-PRs' to this list, to avoid making another 200 API calls per run of this script.
+json_files=("queue.json" "queue-new-contributor.json" "ready-to-merge.json" "automerge.json" "maintainer-merge.json" "delegated.json" "new-contributor.json")
 
 # Output file
 pr_info="pr-info.json"
@@ -117,7 +118,7 @@ do
   #   '.[$pr_number] = {additions: $additions, deletions: $deletions, changed_files: $changed_files}' $pr_info > temp.json && mv temp.json $pr_info
 done
 
-python3 ./dashboard.py $pr_info ${json_files[*]} > ./dashboard.html
+python3 ./dashboard.py $pr_info ${json_files[*]} "all-ready-prs.jon" > ./dashboard.html
 
 rm *.json
 

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -118,7 +118,7 @@ do
   #   '.[$pr_number] = {additions: $additions, deletions: $deletions, changed_files: $changed_files}' $pr_info > temp.json && mv temp.json $pr_info
 done
 
-python3 ./dashboard.py $pr_info ${json_files[*]} "all-ready-prs.jon" > ./dashboard.html
+python3 ./dashboard.py $pr_info "all-ready-prs.jon" ${json_files[*]} > ./dashboard.html
 
 rm *.json
 


### PR DESCRIPTION
- filter the query of PRs without an area label to feature PRs
For, say, a PR performing a chore across mathlib, not having an area label can actually make sense.
- add a list of PRs whose title does not start with one of the common abbreviation

Both lists ignore WIP and draft PRs: once a PR is marked ready, the idea is that it should be title appropriately.