### PR TITLE
feat: print statistics about the overall status of each PR

### DIFF
--- a/classify_pr_state.py
+++ b/classify_pr_state.py
@@ -1,0 +1,229 @@
+'''Helper utilities for determining the current state of a pull request from e.g. its labels.'''
+from datetime import datetime
+from enum import Enum, auto
+from typing import List, NamedTuple
+
+
+# The different kinds of PR labels we care about.
+# We usually do not care about the precise label names, but just their function.
+class LabelKind(Enum):
+    WIP = auto()  # WIP
+    Review = auto()
+    """This PR is ready for review: this label is only added for historical purposes, as mathlib does not use this label any more"""
+    Author = auto()  # awaiting-author
+    MergeConflict = auto()  # merge-conflict
+    Blocked = auto()  # blocked-by-other-PR, etc.
+    Decision = auto()  # awaiting-zulip
+    Delegated = auto()  # delegated
+    Bors = auto()  # ready-to-merge or auto-merge-after-CI
+    # any other label, such as t-something (but also "easy", "bug" and a few more)
+    Other = auto()
+
+
+# Map a label name (as a string) to a `LabelKind`.
+#
+# NB. Make sure this mapping reflects the *current* label names on github.
+# For historical purposes, it might be necessary to also track their
+# historical names: for the current use of this code, this is not an issue.
+label_categorisation_rules: dict[str, LabelKind] = {
+    "WIP": LabelKind.WIP,
+    "awaiting-review-DONT-USE": LabelKind.Review,
+    "awaiting-author": LabelKind.Author,
+    "blocked-by-other-PR": LabelKind.Blocked,
+    "blocked-by-batt-PR": LabelKind.Blocked,
+    "blocked-by-core-PR": LabelKind.Blocked,
+    "blocked-by-qq-PR": LabelKind.Blocked,
+    "blocked-by-core-relase": LabelKind.Blocked,
+    "merge-conflict": LabelKind.MergeConflict,
+    "awaiting-zulip": LabelKind.Decision,
+    "delegated": LabelKind.Delegated,
+    "ready-to-merge": LabelKind.Bors,
+    "auto-merge-after-CI": LabelKind.Bors,
+}
+
+
+class CIStatus(Enum):
+    Pass = auto()
+    Fail = auto()
+    Running = auto()
+
+
+# All relevant state of a PR at each point in time.
+class PRState(NamedTuple):
+    labels: List[LabelKind]
+    ci: CIStatus
+    draft: bool
+    """True if and only if this PR is marked as draft."""
+
+    @staticmethod
+    def with_labels(labels : List[LabelKind]):
+        '''Create a PR state with just these labels, passing CI and ready for review'''
+        return PRState(labels, CIStatus.Pass, False)
+
+
+# Describes the current status of a pull request in terms of the categories we care about.
+class PRStatus(Enum):
+    # This PR is marked as work in progress, is in draft state or CI fails.
+    # CI running is ignored, as this ought to be intermittent.
+    NotReady = auto()
+    # This PR is blocked on another PR, to mathlib, core or batteries.
+    Blocked = auto()
+    AwaitingReview = auto()
+    # Review comments to process: different from "not ready"
+    AwaitingAuthor = auto()
+    # This PR is blocked on a decision: the awaiting-zulip label signifies this.
+    AwaitingDecision = auto()
+    # This PR has a merge conflict and is ready, not blocked on another PR,
+    # not awaiting author action and and otherwise awaiting review.
+    # (Put differently, "blocked", "not ready" or "awaiting-author" take precedence over a merge conflict.)
+    MergeConflict = auto()
+    # This PR was delegated to the user.
+    Delegated = auto()
+    # Ready-to-merge or auto-merge-after-CI. Can become stale if CI fails/multiple retries etc.
+    AwaitingBors = auto()
+    # FIXME: do we actually need this category?
+    Closed = auto()
+    Contradictory = auto()
+    """PR labels are contradictory: we cannot determine easily what this PR's status is"""
+
+
+def label_to_prstatus(label: LabelKind) -> PRStatus:
+    return {
+        LabelKind.WIP: PRStatus.NotReady,
+        LabelKind.Review: PRStatus.AwaitingReview,
+        LabelKind.Author: PRStatus.AwaitingAuthor,
+        LabelKind.Blocked: PRStatus.Blocked,
+        LabelKind.MergeConflict: PRStatus.MergeConflict,
+        LabelKind.Decision: PRStatus.AwaitingDecision,
+        LabelKind.Delegated: PRStatus.Delegated,
+        LabelKind.Bors: PRStatus.AwaitingBors,
+    }[label]
+
+
+def determine_PR_status(date: datetime, state: PRState) -> PRStatus:
+    '''Determine a PR's status from its state
+    'date' is necessary as the interpretation of the awaiting-review label changes over time'''
+    if state.draft or state.ci == CIStatus.Fail:
+        return PRStatus.NotReady
+    # Ignore all "other" labels, which are not relevant for this anyway.
+    labels = [l for l in state.labels if l != LabelKind.Other]
+
+    # Labels can be contradictory (so we need to recognise this).
+    # Also note that their priority orders are not transitive!
+    # TODO: is this actually a problem for our algorithm?
+    # NB. A PR *can* legitimately have *two* labels of a blocked kind, for example,
+    # so we *do not* want to deduplicate the kinds here.
+    if labels == []:
+        # Until July 9th, a PR had to be labelled awaiting-review to be marked as such.
+        # After that date, the label is retired and PRs are considered ready for review
+        # by default.
+        if date > datetime(2024, 7, 9):
+            return PRStatus.AwaitingReview
+        else:
+            return PRStatus.AwaitingAuthor
+    elif len(labels) == 1:
+        return label_to_prstatus(labels[0])
+    else:
+        # Some label combinations are contradictory. We mark the PR as in a "contradictory" state.
+        # awaiting-decision is exclusive with any of waiting on review, author, delegation and sent to bors.
+        if LabelKind.Decision in labels and any([l for l in labels if
+                l in [LabelKind.Author, LabelKind.Review, LabelKind.Delegated, LabelKind.Bors, LabelKind.WIP]]):
+            #print(f"contradictory label kinds: {labels}")
+            return PRStatus.Contradictory
+        # Work in progress contradicts "awaiting review" and "ready for bors".
+        if LabelKind.WIP in labels and any([l for l in labels if l in [LabelKind.Review, LabelKind.Bors]]):
+            #print(f"contradictory label kinds: {labels}")
+            return PRStatus.Contradictory
+        # Waiting for the author and review is also contradictory,
+        if LabelKind.Author in labels and LabelKind.Review in labels:
+            #print(f"contradictory label kinds: {labels}")
+            return PRStatus.Contradictory
+        # as is being ready-for-merge and blocked.
+        if LabelKind.Bors in labels and LabelKind.Blocked in labels:
+            #print(f"contradictory label kinds: {labels}")
+            return PRStatus.Contradictory
+
+        # If the set of labels is not contradictory, we use a clear priority order:
+        # from highest to lowest priority, the label kinds are ordered as
+        # blocked > WIP > merge conflict > bors > decision > author; review > delegate.
+        # We can simply use Python's sorting to find the highest priority label.
+        key: dict[LabelKind, int] = {
+            LabelKind.Blocked: 10,
+            LabelKind.WIP: 9,
+            LabelKind.MergeConflict: 8,
+            LabelKind.Bors: 7,
+            LabelKind.Decision: 6,
+            LabelKind.Author: 5,
+            LabelKind.Review: 5,
+            LabelKind.Delegated: 4,
+        }
+        sorted_labels = sorted(labels, key=lambda k: key[k], reverse=True)
+        return label_to_prstatus(sorted_labels[0])
+
+
+def test_determine_status() -> None:
+    # NB: this only tests the new handling of awaiting-review status.
+    default_date = datetime(2024, 8, 1)
+    def check(labels: List[LabelKind], expected: PRStatus) -> None:
+        state = PRState.with_labels(labels)
+        actual = determine_PR_status(default_date, state)
+        assert expected == actual, f"expected PR status {expected} from labels {labels}, got {actual}"
+    # This version takes a PR state instead.
+    def check2(state: PRState, expected: PRStatus) -> None:
+        actual = determine_PR_status(default_date, state)
+        assert expected == actual, f"expected PR status {expected} from state {state}, got {actual}"
+    # Check if the PR status on a given list of labels in one of several allowed values.
+    # If successful, returns the actual PR status computed.
+    def check_flexible(labels: List[LabelKind], allowed: List[PRStatus]) -> PRStatus:
+        state = PRState(labels, CIStatus.Pass, False)
+        actual = determine_PR_status(default_date, state)
+        assert actual in allowed, f"expected PR status in {allowed} from labels {labels}, got {actual}"
+        return actual
+
+    # Tests for handling draft and CI state.
+    # These take precedence over any other labels.
+    check2(PRState([], CIStatus.Pass, True), PRStatus.NotReady)
+    check2(PRState([], CIStatus.Fail, False), PRStatus.NotReady)
+    check2(PRState([], CIStatus.Fail, True), PRStatus.NotReady)
+    # Running CI is treated as "passing" for the purposes of our classification.
+    check2(PRState([], CIStatus.Running, False), PRStatus.AwaitingReview)
+    check2(PRState([LabelKind.WIP], CIStatus.Fail, False), PRStatus.NotReady)
+    check2(PRState([LabelKind.MergeConflict], CIStatus.Fail, False), PRStatus.NotReady)
+
+    # All label kinds we distinguish.
+    ALL = LabelKind._member_map_.values()
+    # For each combination of labels, the resulting PR status is either contradictory
+    # or the status associated to some label.
+    # The order of adding labels does not matter.
+    check([], PRStatus.AwaitingReview)
+    check([LabelKind.Other], PRStatus.AwaitingReview)
+    check([LabelKind.Other, LabelKind.Other], PRStatus.AwaitingReview)
+    check([LabelKind.Other, LabelKind.Other, LabelKind.Other], PRStatus.AwaitingReview)
+    for a in ALL:
+        if a != LabelKind.Other:
+            check([a], label_to_prstatus(a))
+        for b in ALL:
+            statusses = [label_to_prstatus(l) for l in [a, b] if l != LabelKind.Other]
+            # The "other" kind has no associated PR state: continue if all labels are "other"
+            if not statusses:
+                continue
+            actual = check_flexible([a, b], statusses + [PRStatus.Contradictory])
+            check([b, a], actual)
+            result_ab = actual
+            for c in ALL:
+                # Adding further labels to some contradictory status remains contradictory.
+                if result_ab == PRStatus.Contradictory:
+                    check([a, b, c], PRStatus.Contradictory)
+                else:
+                    statusses = [label_to_prstatus(l) for l in [a, b, c] if l != LabelKind.Other]
+                    if not statusses:
+                        continue
+                    actual = check_flexible([a, b, c], statusses + [PRStatus.Contradictory])
+                    check([a, c, b], actual)
+                    check([b, a, c], actual)
+                    check([b, c, a], actual)
+                    check([c, a, b], actual)
+                    check([c, b, a], actual)
+    # One specific sanity check, which fails in the previous implementation.
+    check([LabelKind.Blocked, LabelKind.Review], PRStatus.Blocked)
+    check([LabelKind.Review, LabelKind.Blocked], PRStatus.Blocked)

--- a/dashboard.py
+++ b/dashboard.py
@@ -106,8 +106,8 @@ def getIdTitle(kind : PRList) -> Tuple[str, str]:
 
 def main() -> None:
     # Check if the user has provided the correct number of arguments
-    if len(sys.argv) < 3:
-        print("Usage: python3 dashboard.py <pr-info.json> <all-ready-prs.json> <json_file1> <json_file2> ...")
+    if len(sys.argv) < 4:
+        print("Usage: python3 dashboard.py <pr-info.json> <all-ready-prs.json> <all-draft-PRs.json> <json_file1> <json_file2> ...")
         sys.exit(1)
 
     print_html5_header()
@@ -121,7 +121,7 @@ def main() -> None:
 
     # Iterate over the json files provided by the user
     dataFilesWithKind = []
-    for i in range(3, len(sys.argv)):
+    for i in range(4, len(sys.argv)):
         filename = sys.argv[i]
         if filename not in EXPECTED_INPUT_FILES:
             print(f"bad argument: file {filename} is not recognised; did you mean one of these?\n{', '.join(EXPECTED_INPUT_FILES.keys())}")

--- a/dashboard.py
+++ b/dashboard.py
@@ -144,6 +144,7 @@ def main() -> None:
 
     print_html5_footer()
 
+
 def print_html5_header() -> None:
     print("""
     <!DOCTYPE html>
@@ -193,7 +194,7 @@ def title_link(title, url) -> str:
     return "<a href='{}'>{}</a>".format(url, title)
 
 
-# The information we need about each PR label: name, colour and URL
+# The information we need about each PR label: its name, background colour and URL
 class Label(NamedTuple):
     name : str
     '''This label's background colour, as a six-digit hexadecimal code'''
@@ -254,6 +255,19 @@ class BasicPRInformation(NamedTuple):
     labels : List[Label]
     # Github's answer to "last updated at"
     updatedAt : str
+
+
+# Extract all PRs mentioned in a list of data files.
+def _extract_prs(datae: List[dict]) -> List[BasicPRInformation]:
+    prs = []
+    for data in datae:
+        for page in data["output"]:
+            for entry in page["data"]["search"]["nodes"]:
+                labels = [Label(label["name"], label["color"], label["url"]) for label in entry["labels"]["nodes"]]
+                prs.append(BasicPRInformation(
+                    entry["number"], entry["author"], entry["title"], entry["url"], labels, entry["updatedAt"]
+                ))
+    return prs
 
 
 # Print table entries about a sequence of PRs.
@@ -317,19 +331,6 @@ def _print_dashboard(pr_infos: dict, prs : List[BasicPRInformation], kind: PRLis
 
     # Print the footer
     print("</table>")
-
-
-# Extract all PRs mentioned in a list of data files.
-def _extract_prs(datae: List[dict]) -> List[BasicPRInformation]:
-    prs = []
-    for data in datae:
-        for page in data["output"]:
-            for entry in page["data"]["search"]["nodes"]:
-                labels = [Label(label["name"], label["color"], label["url"]) for label in entry["labels"]["nodes"]]
-                prs.append(BasicPRInformation(
-                    entry["number"], entry["author"], entry["title"], entry["url"], labels, entry["updatedAt"]
-                ))
-    return prs
 
 
 def print_dashboard(datae : List[dict], kind : PRList) -> None:

--- a/dashboard.py
+++ b/dashboard.py
@@ -130,20 +130,26 @@ def main() -> None:
             data = json.load(f)
             dataFilesWithKind.append((data, EXPECTED_INPUT_FILES[filename]))
 
-    # Process all data files for the same PR list together.
-    for kind in PRList._member_map_.values():
-        # For these kinds, we create a dashboard later (by filtering the list of all ready PRs instead).
-        if kind in [PRList.Unlabelled, PRList.BadTitle, PRList.ContradictoryLabels]:
-            continue
-        datae = [d for (d, k) in dataFilesWithKind if k == kind]
-        print_dashboard(datae, kind)
+    with open(sys.argv[2]) as ready_file, open(sys.argv[3]) as draft_file:
+        all_ready_prs = json.load(ready_file)
+        all_draft_prs = json.load(draft_file)
+        gather_pr_statistics(dataFilesWithKind, all_ready_prs, all_draft_prs)
 
-    with open(sys.argv[2]) as f:
-        all_ready_prs = json.load(f)
+        # Process all data files for the same PR list together.
+        for kind in PRList._member_map_.values():
+            # For these kinds, we create a dashboard later (by filtering the list of all ready PRs instead).
+            if kind in [PRList.Unlabelled, PRList.BadTitle, PRList.ContradictoryLabels]:
+                continue
+            datae = [d for (d, k) in dataFilesWithKind if k == kind]
+            print_dashboard(datae, kind)
+
         print_dashboard_bad_labels_title(all_ready_prs)
 
     print_html5_footer()
 
+
+def gather_pr_statistics(dataFilesWithKind: List[Tuple[dict, PRList]], all_ready_prs: dict, all_draft_prs: dict) -> str:
+    pass  # TODO
 
 def print_html5_header() -> None:
     print("""

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -91,8 +91,13 @@ gh api graphql --paginate --slurp -f query="$QUERY_PLEASE_ADOPT" | jq '{"output"
 QUERY_READY=$(prepare_query 'sort:updated-asc is:pr -is:draft state:open -label:WIP')
 gh api graphql --paginate --slurp -f query="$QUERY_READY" | jq '{"output": .}' > all-ready-PRs.json
 
+# Query Github API for all open pull requests which are in draft status
+QUERY_DRAFT=$(prepare_query 'sort:updated-asc is:pr is:draft state:open')
+gh api graphql --paginate --slurp -f query="$QUERY_DRAFT" | jq '{"output": .}' > all-draft-PRs.json
+
 # List of JSON files: their order does not matter for the generated output.
-# NB: we purposefully do not add 'all-ready-PRs' to this list, to avoid making another 200 API calls per run of this script.
+# NB: we purposefully do not add 'all-ready-PRs' or 'all-draft-PRs' to this list,
+# as each PR means an additional API call, and we don't need this specific information here
 json_files=("queue.json" "queue-new-contributor.json" "needs-merge.json" "ready-to-merge.json" "automerge.json" "maintainer-merge.json" "needs-decision.json" "delegated.json" "new-contributor.json" "help-wanted.json" "please-adopt.json")
 
 # Output file
@@ -131,7 +136,7 @@ do
   #   '.[$pr_number] = {additions: $additions, deletions: $deletions, changed_files: $changed_files}' $pr_info > temp.json && mv temp.json $pr_info
 done
 
-python3 ./dashboard.py $pr_info "all-ready-PRs.json" ${json_files[*]} > ./dashboard.html
+python3 ./dashboard.py $pr_info "all-ready-PRs.json" "all-draft-PRs.json" ${json_files[*]} > ./dashboard.html
 
 rm *.json
 


### PR DESCRIPTION
This question came up [on zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Number.20of.20open.20PRs): the review queue is only a fraction of the set of open PRs, so having better insight into the whole distribution of statusses is useful.

This PR
- adds a new query, for all draft PRs (there was only a query for all *ready* PRs)
Querying for *all* open PRs and filtering is not an option, as the PR stage (draft/ready) is not returned through the default query, it is only returned in individual PR's information, which we would like to avoid querying, for performance reasons.
- add new logic for classifying each PR's status (taken from #25)
- determines the number of PRs in each possible statue and prints some information about this
The output presentation could be improved (for instance, it leaks the internal status names), but it's a start.