### PR TITLE
feat: allow filtering each dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -270,8 +270,8 @@ def print_html5_footer() -> None:
     <script>
     $(document).ready( function () {
         $('table').DataTable({
-                pageLength: 10,
-				"searching": false,
+            pageLength: 10,
+			"searching": true,
         });
     });
     </script>


### PR DESCRIPTION
This allows manually filtering the PR labels (or title) by just entering (part of) the label name.
Fixes #3.