### PR TITLE
refactor/change: change source of detailed PR information

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,11 +4,12 @@ This document describes the high-level architecture of the review dashboard. If 
 
 ## High-level overview
 This repository contains code and a github workflow to generate the mathlib review dashboard.
-The high-level overview of the workflow is the following.
+Generating a dashboard requires several steps.
 - step 1: query github's API for information on open pull requests
+This happens asynchronously from the remaining tasks.
 - step 2: generate a static webpage from this information
 - step 3: publish this webpage using github pages
-These steps are repeated regularly, using a cronjob. Currently (as of October 8, 2024), a workflow run takes about 5 minutes, and a new job starts eight minutes after the previous run. All in all, this means the data on the dashboard has a latency of 12--15 minutes.
+These steps are repeated regularly, using a cronjob. Step 1 happens asynchronously of steps 2 and 3. Currently (as of October 8, 2024), a workflow run takes about 5 minutes, and a new job starts eight minutes after the previous run. All in all, this means the data on the dashboard has a latency of 12--15 minutes.
 
 ## Relevant files
 This section talks briefly about various important directories and data structures. Pay attention to the Architecture Invariant sections. They often talk about things which are deliberately absent in the source code.
@@ -18,11 +19,15 @@ This section talks briefly about various important directories and data structur
 - it then calls `dashboard.py` (with the JSON files passed as explicit arguments) to create a dashboard.
 *Currently*, all data has to be regenerated upon every call of the script.
 
-**Architecture invariant.** All network requests happen in this script. `dashboard.py` makes no connections to the network.
+**TODO** mention the `data` directory, and the `gather_stats.sh` script (with its dependencies).
+Mention `process.py` and its generated file!
 
-`dashboard.py` is where the core logic of creating the dashboard lives. It is a Python script, taking the JSON files from the previous step as input. It prints the HTML code for the dashboard page. It also writes the HTML code for a page "is my PR on the queue" to a separate file `on_the_queue.html`.
+**Architecture invariant.** All network requests happen in this script (TODO and the others!).
+`dashboard.py` makes no connections to the network.
 
-**Architecture invariant.** The output of `dashboard.py` only depends on its command line arguments and its current time: with both fixed, it is deterministic. In particular, it makes no network request.
+`dashboard.py` is where the core logic of creating the dashboard lives. It is a Python script, taking the JSON files from the previous step and the detailed PR information in `data` as input. It prints the HTML code for the dashboard page. It also writes the HTML code for a page "is my PR on the queue" to a separate file `on_the_queue.html`.
+
+**Architecture invariant.** The output of `dashboard.py` only depends on its command line arguments, the contents of the `data` directory and its current time: with both fixed, it is deterministic. In particular, it makes no network requests. All I/O in that file is constrained to one method `read_user_data` in the beginning.The output of `dashboard.py` only depends on its command line arguments and its current time: with both fixed, it is deterministic. In particular, it makes no network requests.
 All I/O in that file is constrained to one method `read_user_data` in the beginning.
 
 `.github/workflows/publish-dashboard.yml` defines the workflow updating the dashboard. It runs the above scripts to generate an up-to-date dashboard, and commits the updated HTML file on the `gh-pages` branch. That branch is deployed by github pages to create the webpage.
@@ -34,7 +39,14 @@ All I/O in that file is constrained to one method `read_user_data` in the beginn
 
 `test` contains versions of all input files to this script, at some point in time. These can be used for locally testing `dashboard.py`.
 
+**TODO** document the remaining files!
+
+
 # Cross-cutting concerns
+
+## Limiting github API calls
+Each github API call is expensive: github (understandably) adds rate limiting to each call to its API: successive calls can happen at most once per second. This imposes a natural lower bound on the execution time of this script.
+In particular, each query for each dashboard takes one second: if easily possible/the data for a particular dashboard can be easily derived (e.g., filtered) from existing data, avoiding an API call and a separate JSON file is preferred.
 
 ## Testing
 There are several levels at which this project can be tested. Currently, there are no *automated* tests, but an effort is made that the dashboard logic can easily be tested manually.
@@ -42,13 +54,13 @@ There are several levels at which this project can be tested. Currently, there a
 - `classify_pr_state.py` has unit tests: to run them, use e.g. `nose` (which will pick them up automatically), or uncomment all methods named `test_xxx` and run `python3 classify_pr_state.py`
 - changes to just `dashboard.py` can be tested using the JSON files in `test`, as follows.
 Run the following, *inside* the `test` directory:
-`python3 ../dashboard.py aggregate_info.json pr-info.json all-nondraft-PRs.json all-draft-PRs.json queue.json ready-to-merge.json please-adopt.json new-contributor.json needs-merge.json needs-decision.json maintainer-merge.json help-wanted.json delegated.json automerge.json > ../expected.html`,
+`python3 ../dashboard.py aggregate_info.json all-nondraft-PRs.json all-draft-PRs.json queue.json ready-to-merge.json please-adopt.json new-contributor.json needs-merge.json needs-decision.json maintainer-merge.json help-wanted.json delegated.json automerge.json > ../expected.html`,
 once (before the changes) to create a file `../expected.html`, and again afterwards for a file `../actual.html`.
 You can then use `diff` to look for any changes to the generated output.
 (The output file needs to be in the top-level directory in order for the styling to work.)
 
 ## TODO document
 - `data` directory, metadata updating via `gather_stats.sh` (and the other workflow)
-data integrity check (once written)
+- data integrity check (once written)
 
 - additional tools for testing `mypy`, `ruff`, `isort`, (black)

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -96,49 +96,13 @@ gh api graphql --paginate --slurp -f query="$QUERY_DRAFT" | jq '{"output": .}' >
 
 # List of JSON files: their order does not matter for the generated output.
 # NB: we purposefully do not add 'all-nondraft-PRs' or 'all-draft-PRs' to this list,
-# as each PR means an additional API call, and we don't need this specific information here
+# as they do not correspond to a dashboard to be generated.
 json_files=("queue.json" "needs-merge.json" "ready-to-merge.json" "automerge.json" "maintainer-merge.json" "needs-decision.json" "delegated.json" "new-contributor.json" "help-wanted.json" "please-adopt.json" "other-base-branch.json")
-
-# Output file
-pr_info="pr-info.json"
-
-# Empty the output file
-echo "{}" > $pr_info
-
-# Create an empty array to store PR numbers
-declare -A pr_numbers
-
-# For each JSON file
-for json_file in "${json_files[@]}"
-do
-  # Get the PR numbers and add them to the array
-  while read -r pr_number; do
-    pr_numbers["$pr_number"]=1
-  done < <(jq -r '.output[]["data"]["search"]["nodes"][]["number"]' $json_file)
-done
-
-# For each unique PR number
-for pr_number in "${!pr_numbers[@]}"
-do
-  # Get the diff info
-  diff_info=$(gh api repos/leanprover-community/mathlib4/pulls/$pr_number)
-
-  # # Get the additions, deletions, and changed files
-  # additions=$(echo $diff_info | jq '.additions')
-  # deletions=$(echo $diff_info | jq '.deletions')
-  # changed_files=$(echo $diff_info | jq '.changed_files')
-
-  # Add the diff info to the output file
-  jq --arg pr_number "$pr_number" --argjson diff_info "$diff_info" \
-    '.[$pr_number] = $diff_info' $pr_info > temp.json && mv temp.json $pr_info
-  # jq --arg pr_number "$pr_number" --argjson additions "$additions" --argjson deletions "$deletions" --argjson changed_files "$changed_files" \
-  #   '.[$pr_number] = {additions: $additions, deletions: $deletions, changed_files: $changed_files}' $pr_info > temp.json && mv temp.json $pr_info
-done
 
 # Download a file with aggregate info, e.g. the CI status of each open PR.
 curl --silent --output aggregate_info.json https://raw.githubusercontent.com/jcommelin/gh-mathlib-metadata/refs/heads/master/processed_data/aggregate_pr_data.json
 
-python3 ./dashboard.py aggregate_info.json $pr_info "all-nondraft-PRs.json" "all-draft-PRs.json" ${json_files[*]} > ./index.html
+python3 ./dashboard.py aggregate_info.json "all-nondraft-PRs.json" "all-draft-PRs.json" ${json_files[*]} > ./index.html
 
 rm *.json
 


### PR DESCRIPTION
Instead of calling the github API each time, yielding a one second delay per PR query (imposed by Github's rate limiting), use the detailed information from `data` directory instead. (That directory has the relevant PR data downloaded already, and updated automatically --- effectively providing a cache for these API calls.
Additionally, the file in that repo contain more comprehensive information about each PR: this change in data format is necessary anyway to roll out #25 and #35.

Particular changes
- remove any reference to print_info.json from dashboard.sh and the script
- inline _print_dashboard, and remove the last argument from it.

This PR is **not** exhaustive on updating all documentation: this can happen latter, when this change is tested and works.