### PR TITLE
Underline links in style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -2,6 +2,11 @@ a {
 	all: unset;
 }
 
+/* Underline links, but not in headings or inside tables */
+a:not(table a, h1 a, h2 a, h3 a, h4 a, h5 a, h6 a) {
+	text-decoration: underline;
+}
+
 a:hover {
 	text-decoration: underline;
 	cursor: pointer;


### PR DESCRIPTION
The text paragraphs on the the queueboard contain many helpful links, but at the moment they are quite difficult to discover without hovering over the entire text. How about always underlining them?

![image](https://github.com/user-attachments/assets/17998f4a-7d94-4862-8111-81273c8381f0)
