### PR TITLE
change(dashboard.py): use aggregate data as single source of truth

### DIFF
--- a/.github/workflows/regenerate_dashboard.yml
+++ b/.github/workflows/regenerate_dashboard.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: "Regenerate the dashboard webpages"
       run: |
-        python3 ./dashboard.py "all-open-PRs-1.json" "all-open-PRs-2.json" > ./index-old.html
+        python3 ./dashboard.py
         rm *.json
 
     - name: Commit and push changes

--- a/.github/workflows/update_metadata.yml
+++ b/.github/workflows/update_metadata.yml
@@ -78,7 +78,7 @@ jobs:
     - name: "Regenerate the dashboard webpages"
       if: ${{ !cancelled() }} && (steps.download-json.outcome == 'success')
       run: |
-        python3 ./dashboard.py "all-open-PRs-1.json" "all-open-PRs-2.json" > ./index-old.html
+        python3 ./dashboard.py
         rm *.json
 
     - name: Commit and push changes

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -106,7 +106,7 @@ There are several levels at which this project can be tested. Currently, there a
 
 TODO: there are more generated HTML files now; recommend copying the folder instead...
 - changes to just `dashboard.py` can be tested using the JSON files in the `test` directory: run the following from the `test` directory.
-`python3 ../dashboard.py all-open-PRs-1.json all-open-PRs-2.json`.
+`python3 ../dashboard.py`.
 This creates two webpages named `on_the_queue.html` and `index.html`, overwriting any previous files named thus.
 You can run this command before and after your changes and compare the resulting files (using `diff` or a similar tool). Because of the overwriting, take care to copy e.g. the old version of the output to a different file before running the tool again.
 (The output file needs to be in the top-level directory in order for the styling to work.)

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -13,7 +13,7 @@ This is not difficult, but requires changes in multiple stages.
 1. Edit `process.py`, change the `get_aggregate_data` function to extract the data you want.
 Pay attention to the fact that there is "basic" and "full" PR info; not all information might be available in both files.
 2. Run `process.py` locally to update the generated file; commit the changes (except for the changed time-stamp). This step is optional; you can also just push the previous step and let CI perform this update.
-3. Once step 2 is complete, edit the definition of `AggregatePRInfo` in `dashboard.py` to include your new data field. Update `PLACEHOLDER_AGGREGATE_INFO` as well. Update `read_json_files` to parse this field as well.
+3. Once step 2 is complete, edit the definition of `AggregatePRInfo` in `dashboard.py` to include your new data field. Update `read_json_files` to parse this field as well.
 4. Congratulations, now you have made some new metadata available to the dashboard processing. (For making use of this, see the previous bullet point for changing the dashboard.)
 
 

--- a/generate_assigment_page.py
+++ b/generate_assigment_page.py
@@ -36,12 +36,10 @@ from dashboard import (
 
 # Assumes the aggregate data is correct: no cross-filling in of placeholder data.
 def compute_pr_list_from_aggregate_data_only(aggregate_data: dict[int, AggregatePRInfo]) -> dict[Dashboard, List[BasicPRInformation]]:
-    all_open_prs: List[BasicPRInformation] = []
     nondraft_PRs: List[BasicPRInformation] = []
     for number, data in aggregate_data.items():
         if data.state == "open":
             info = BasicPRInformation(number, data.author, data.title, infer_pr_url(number), data.labels, data.last_updated)
-            all_open_prs.append(info)
             if not data.is_draft:
                 nondraft_PRs.append(info)
     CI_status: dict[int, CIStatus] = dict()
@@ -54,7 +52,7 @@ def compute_pr_list_from_aggregate_data_only(aggregate_data: dict[int, Aggregate
     for pr in nondraft_PRs:
         base_branch[pr.number] = aggregate_data[pr.number].base_branch
     prs_from_fork = [pr for pr in nondraft_PRs if aggregate_data[pr.number].head_repo != "leanprover-community"]
-    return determine_pr_dashboards(all_open_prs, nondraft_PRs, base_branch, prs_from_fork, CI_status, aggregate_data, True)
+    return determine_pr_dashboards(all_open_prs, nondraft_PRs, base_branch, prs_from_fork, CI_status, aggregate_data)
 
 
 class ReviewerInfo(NamedTuple):


### PR DESCRIPTION
This simplifies both the webpage generation (no dependency on the .json files) and the code, conceptually. It allows removing all filling in of placeholders.

Further clean-ups left for the future include
- remove a now-duplicate method in generate_assignment_page
- removing the BasicPRInformation class, as its content is essentially a subset of the aggregate PR information.

Landing this depends on PR data being updated reliably: not yet.